### PR TITLE
Add options.args to overlays

### DIFF
--- a/modules/overlay.nix
+++ b/modules/overlay.nix
@@ -17,20 +17,25 @@ in {
           type = lib.types.path;
           description = "The folder to auto discover packages.";
         };
+        options.args = lib.options.create {
+            description = "Additional arguments to pass to overlayied packages.";
+            type = lib.types.attrs.any;
+            default.value = {};
+          };
       }));
     };
   };
 
   config = {
     overlays = let
-      mkOverlayFromDir = dir: (f: p: (
+      mkOverlayFromDir = dir: args: (f: p: (
         mapAttrs
-        (_: d: f.callPackage d {})
+        (_: d: f.callPackage d args)
         (lib.utils.loadDirsWithFile "default.nix" dir)
       ));
     in
       mapAttrs
-      (_: opts: mkOverlayFromDir opts.folder)
+      (_: opts: mkOverlayFromDir opts.folder opts.args)
       config.generators.overlays;
   };
 }

--- a/modules/shells.nix
+++ b/modules/shells.nix
@@ -14,7 +14,7 @@ in {
       default.value = "nixpkgs";
     };
     settings = let
-      builder = config.builders.${config.generators.packages.builder};
+      builder = config.builders.${config.generators.shells.builder};
     in
       lib.options.create {
         description = "Additional configuration to use when loading when loading the shells.";


### PR DESCRIPTION
This change adds `args` option to `generators.overlays` so it'll be easier to pass additional arguments to packages and use those packages as overlays.

Example usage:
```
generators.overlays.default.folder = ./packages;
generators.overlays.default.args = {
  project = config;
};
```