### PR TITLE
Add generators for NixOS/home-manager modules

### DIFF
--- a/modules/project.nix
+++ b/modules/project.nix
@@ -26,7 +26,9 @@ in {
         shells.folder = "${folder}/shells";
         overlays.default.folder = "${folder}/packages";
         nixos.folder = "${folder}/hosts";
+        nixosModules.folder = "${folder}/modules/nixos";
         home.folder = "${folder}/hosts";
+        homeModules.folder = "${folder}/modules/home";
 
         # Since the project generators sets default
         # paths for all we do not want to fail assertions


### PR DESCRIPTION
**didn't test it yet because I'm in the middle of adapting my config** - but `nilla show` works

Adds a functionality to generate NixOS/home-manager modules from a structure of files like this:

```
modules/home/desktop/default.nix
modules/home/common/default.nix
modules/nixos/common/default.nix
modules/nixos/desktop/default.nix
```
will generate:

```
Modules (home)

Modules which are available from this Nilla project to use with home.

┌─────────┐
│ Name    │
├─────────┤
│ common  │
├─────────┤
│ desktop │
└─────────┘


 Modules (nixos)

Modules which are available from this Nilla project to use with nixos.

┌──────────────────────┐
│ Name                 │
├──────────────────────┤
│ common               │
├──────────────────────┤
│ desktop              │
└──────────────────────┘
```