### PR TITLE
Fix lix warnings from exiting otherwise successful builds

### DIFF
--- a/internal/tui/build_reporter.go
+++ b/internal/tui/build_reporter.go
@@ -115,8 +115,12 @@ func (m buildModel) handleEvent(ev nix.Event) (tea.Model, tea.Cmd) {
 
 		// error
 		if event.Level == 0 {
-			m.err = errors.New(event.Text)
-			return m, nil
+			// Lix does not have builtins.warn, this means warnings are logged at log level error
+			traceWarning := strings.HasPrefix(event.Text, "trace: ") && strings.Contains(event.Text, "warning:")
+			if !traceWarning {
+				m.err = errors.New(event.Text)
+				return m, nil
+			}
 		}
 
 		// Just display the message


### PR DESCRIPTION
Lix logs `lib.warn` at the error log level, this causes the build reporter to report a failure.

We can read the message to determine if it came from `builtins.trace` and therefore was a `lib.warn` call.

Fixes #14 

Feel free to adjust or not use this, it feels a bit hacky but I couldn't see any other obvious method to stop warnings from causing an exit, without redoing a bunch of work :)