### PR TITLE
feat: remote generations support and centralized sudo handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,20 +184,20 @@ For managing NixOS systems defined in `systems.nixos`.
     ```sh
     nilla os build <system_name>
     # Build on remote host:
-    # nilla os build <system_name> --build-on user@hostname
+    # nilla os build <system_name> --build-on <user@target>
     # Build on same host as target:
-    # nilla os build <system_name> --target user@hostname --build-on-target
+    # nilla os build <system_name> --target <user@target> --build-on-target
     ```
 
 *   **Build and switch to a configuration:**
     ```sh
     nilla os switch <system_name>
     # For remote targets:
-    # nilla os switch <system_name> --target user@hostname
+    # nilla os switch <system_name> --target <user@target>
     # Build on remote, deploy to different host:
-    # nilla os switch <system_name> --build-on user@builder --target user@hostname
+    # nilla os switch <system_name> --build-on user@builder --target <user@target>
     # Build and deploy to same host:
-    # nilla os switch <system_name> --target user@hostname --build-on-target
+    # nilla os switch <system_name> --target <user@target> --build-on-target
     ```
 *   **Test a configuration:**
     ```sh
@@ -215,6 +215,9 @@ For managing NixOS systems defined in `systems.nixos`.
     ```sh
     nilla os generations list
     nilla os generations clean --keep 3 # Keeps the last 3 generations
+    # For remote targets:
+    nilla os --target <user@target> generations list
+    nilla os --target <user@target> generations clean --keep 3
     ```
     Use `nilla os --help` or `nilla os <subcommand> --help` for more details.
 
@@ -226,19 +229,19 @@ For managing Home Manager configurations defined in `systems.home`.
     ```sh
     nilla home build <user@system_name>
     # Build on remote host:
-    # nilla home build <user@system_name> --build-on user@hostname
+    nilla home build <user@system_name> --build-on <user@build-target>
     # Build on same host as target:
-    # nilla home build <user@system_name> --target user@hostname --build-on-target
+    nilla home build <user@system_name> --target <user@target> --build-on-target
     ```
 *   **Build and switch to a configuration:**
     ```sh
     nilla home switch <user@system_name>
     # For remote targets:
-    # nilla home switch <user@system_name> --target user@hostname
+    nilla home switch <user@system_name> --target <user@target>
     # Build on remote, deploy to different host:
-    # nilla home switch <user@system_name> --build-on user@builder --target user@hostname
+    nilla home switch <user@system_name> --build-on <user@build-target> --target <user@target>
     # Build and deploy to same host:
-    # nilla home switch <user@system_name> --target user@hostname --build-on-target
+    nilla home switch <user@system_name> --target <user@target> --build-on-target
     ```
 *   **List available Home Manager configurations:**
     ```sh
@@ -248,6 +251,15 @@ For managing Home Manager configurations defined in `systems.home`.
     ```sh
     nilla home generations list
     nilla home generations clean --keep 3 # Keeps the last 3 generations
+    # For remote host - connect as current user:
+    nilla home --target <target> generations list
+    nilla home --target <target> generations clean --keep 3
+    # For remote host - connect as specific user:
+    nilla home --target <user@target> generations list
+    nilla home --target <user@target> generations clean --keep 3
+    # For remote host - connect as specific user and use specific Home Manager configuration (configuration must exist in "nilla home list" and hostname must match target):
+    nilla home --target <user@target> generations list <user@system_name>
+    nilla home --target <user@target> generations clean --keep 3 <user@system_name>
     ```
     Use `nilla home --help` or `nilla home <subcommand> --help` for more details.
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,8 +1,15 @@
 package exec
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"strconv"
+	"strings"
+
+	"github.com/arnarg/nilla-utils/internal/util"
+	"github.com/charmbracelet/log"
 )
 
 type Executor interface {
@@ -22,4 +29,115 @@ type Command interface {
 	StdinPipe() (io.WriteCloser, error)
 	StdoutPipe() (io.Reader, error)
 	StderrPipe() (io.Reader, error)
+}
+
+// IsRootOnExecutor checks if the current user is root on the given executor.
+// For local executors, uses util.IsRoot(). For remote executors, runs "id -u" and checks if it returns 0.
+func IsRootOnExecutor(e Executor) (bool, error) {
+	if e == nil || e.IsLocal() {
+		return util.IsRoot(), nil
+	}
+
+	// Check if we're root on remote by running "id -u"
+	cmd, err := e.Command("id", "-u")
+	if err != nil {
+		return false, err
+	}
+
+	var buf bytes.Buffer
+	cmd.SetStdout(&buf)
+	if err := cmd.Run(); err != nil {
+		return false, err
+	}
+
+	uidStr := strings.TrimSpace(buf.String())
+	uid, err := strconv.Atoi(uidStr)
+	if err != nil {
+		return false, err
+	}
+
+	return uid == 0, nil
+}
+
+// CommandWithSudoIfNeeded creates a command with sudo prefix if not root, otherwise without.
+// It automatically checks if the executor is root and only adds sudo if needed.
+func CommandWithSudoIfNeeded(e Executor, cmd string, args ...string) (Command, error) {
+	isRoot, err := IsRootOnExecutor(e)
+	if err != nil {
+		return nil, err
+	}
+
+	if isRoot {
+		return e.Command(cmd, args...)
+	}
+	return e.Command("sudo", append([]string{cmd}, args...)...)
+}
+
+// CommandAsUser creates a command that runs as the specified user with HOME set correctly.
+// It uses "sudo -u <user> -H" to switch to the user and set HOME to their home directory.
+// If the executor is already running as the target user, it runs the command directly.
+func CommandAsUser(e Executor, user string, cmd string, args ...string) (Command, error) {
+	// Check if we're already running as the target user
+	currentUser, err := getCurrentUser(e)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	if currentUser == user {
+		// Already running as target user, no sudo needed
+		return e.Command(cmd, args...)
+	}
+
+	// Use sudo -u <user> -H to switch to user and set HOME from /etc/passwd
+	sudoArgs := []string{"-u", user, "-H", cmd}
+	sudoArgs = append(sudoArgs, args...)
+	return e.Command("sudo", sudoArgs...)
+}
+
+// getCurrentUser gets the current username on the executor
+func getCurrentUser(e Executor) (string, error) {
+	if e == nil || e.IsLocal() {
+		return util.GetUser(), nil
+	}
+
+	// Get username from remote executor
+	cmd, err := e.Command("whoami")
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	cmd.SetStdout(&buf)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// DetermineNewBuildExecutor selects the executor for the new build based on build location and target.
+// If we built remotely, use remote executor for the new build (faster - no copy needed).
+// Otherwise, use local executor for the new build (it exists locally).
+func DetermineNewBuildExecutor(builder, target Executor, buildTarget, storeAddress, targetStr string) (Executor, error) {
+	if buildTarget != "" && storeAddress != "" {
+		// Built remotely
+		if buildTarget == targetStr && targetStr != "" {
+			// Built on same host as deploy target
+			log.Debugf("Using target executor for new build (built on target): %s", targetStr)
+			return target, nil
+		}
+		// Built on different host - create executor for build host
+		log.Debugf("Setting up SSH executor for build target: %s", buildTarget)
+		buildExecutor, err := NewSSHExecutor(buildTarget)
+		if err != nil {
+			log.Debugf("Failed to create SSH executor for build target: %v", err)
+			return nil, fmt.Errorf("failed to create SSH executor for build target: %w", err)
+		}
+		log.Debugf("Using build target executor for new build: %s", buildTarget)
+		return buildExecutor, nil
+	}
+
+	// Built locally - use local executor (build output exists locally)
+	log.Debugf("Using local executor for new build (built locally)")
+	return builder, nil
 }

--- a/internal/exec/ssh.go
+++ b/internal/exec/ssh.go
@@ -167,6 +167,12 @@ func (c *sshCommand) Start() error {
 				if err != nil {
 					return err
 				}
+			} else {
+				// Try to request PTY anyway with default size (might work in some cases)
+				err := c.sess.RequestPty("xterm-256color", 80, 24, modes)
+				if err != nil {
+					log.Debugf("Failed to allocate PTY for sudo command: %v", err)
+				}
 			}
 		}
 	}

--- a/internal/generation/fs.go
+++ b/internal/generation/fs.go
@@ -3,8 +3,13 @@ package generation
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/arnarg/nilla-utils/internal/exec"
 	"github.com/arnarg/nilla-utils/internal/util"
@@ -19,6 +24,22 @@ type homeDirResolver interface {
 type linkReader interface {
 	readLink(path string) (string, error)
 	pathExists(path string) (bool, error)
+}
+
+// dirReader provides a way to read directories
+type dirReader interface {
+	readDir(path string) ([]fs.DirEntry, error)
+	stat(path string) (fs.FileInfo, error)
+}
+
+// fileReader provides a way to read files
+type fileReader interface {
+	readFile(path string) ([]byte, error)
+}
+
+// fileDeleter provides a way to delete files
+type fileDeleter interface {
+	delete(path string) error
 }
 
 // Local implementations
@@ -44,6 +65,28 @@ func (r *localLinkReader) pathExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+type localDirReader struct{}
+
+func (r *localDirReader) readDir(path string) ([]fs.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+func (r *localDirReader) stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+type localFileReader struct{}
+
+func (r *localFileReader) readFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+type localFileDeleter struct{}
+
+func (r *localFileDeleter) delete(path string) error {
+	return os.Remove(path)
 }
 
 // Remote implementations
@@ -107,4 +150,228 @@ func (r *remoteLinkReader) readLink(path string) (string, error) {
 
 func (r *remoteLinkReader) pathExists(path string) (bool, error) {
 	return r.executor.PathExists(path)
+}
+
+type remoteDirReader struct {
+	executor exec.Executor
+}
+
+func (r *remoteDirReader) readDir(path string) ([]fs.DirEntry, error) {
+	// Use ls -1 to list directory entries
+	cmd, err := r.executor.Command("ls", "-1", path)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	cmd.SetStdout(&buf)
+	if err := cmd.Run(); err != nil {
+		// If directory doesn't exist, return empty list
+		return []fs.DirEntry{}, nil
+	}
+
+	// Parse ls output and create entries
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	entries := []fs.DirEntry{}
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Build full path
+		fullPath := filepath.Join(path, line)
+		// Create a simple DirEntry wrapper
+		entries = append(entries, &dirEntryWrapper{name: line, path: fullPath, executor: r.executor})
+	}
+	return entries, nil
+}
+
+// getStatCommand returns the appropriate stat command and arguments for the platform.
+// Linux uses: stat -c "%Y" path
+// macOS/BSD uses: stat -f "%m" path
+func getStatCommand(path string) (string, []string) {
+	// Try to detect platform, default to Linux
+	if runtime.GOOS == "darwin" {
+		return "stat", []string{"-f", "%m", path}
+	}
+	// Default to Linux format
+	return "stat", []string{"-c", "%Y", path}
+}
+
+func (r *remoteDirReader) stat(path string) (fs.FileInfo, error) {
+	// Use stat command via executor to get modtime
+	cmdName, args := getStatCommand(path)
+	statCmd, err := r.executor.Command(cmdName, args...)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	statCmd.SetStdout(&buf)
+	var modTime time.Time
+	if err := statCmd.Run(); err == nil {
+		if timestamp, err := strconv.ParseInt(strings.TrimSpace(buf.String()), 10, 64); err == nil {
+			modTime = time.Unix(timestamp, 0)
+		}
+	}
+	if modTime.IsZero() {
+		modTime = time.Now()
+	}
+
+	// Create a fileInfo wrapper
+	return &fileInfoWrapper{
+		name:    filepath.Base(path),
+		path:    path,
+		modTime: modTime,
+	}, nil
+}
+
+// dirEntryWrapper wraps a remote directory entry
+type dirEntryWrapper struct {
+	name     string
+	path     string
+	executor exec.Executor
+}
+
+func (e *dirEntryWrapper) Name() string {
+	return e.name
+}
+
+func (e *dirEntryWrapper) IsDir() bool {
+	return false // generations are symlinks
+}
+
+func (e *dirEntryWrapper) Type() fs.FileMode {
+	return fs.ModeSymlink
+}
+
+func (e *dirEntryWrapper) Info() (fs.FileInfo, error) {
+	// Use stat command via executor to get modtime
+	cmdName, args := getStatCommand(e.path)
+	statCmd, err := e.executor.Command(cmdName, args...)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	statCmd.SetStdout(&buf)
+	var modTime time.Time
+	if err := statCmd.Run(); err == nil {
+		if timestamp, err := strconv.ParseInt(strings.TrimSpace(buf.String()), 10, 64); err == nil {
+			modTime = time.Unix(timestamp, 0)
+		}
+	}
+	if modTime.IsZero() {
+		modTime = time.Now()
+	}
+	return &fileInfoWrapper{
+		name:    e.name,
+		path:    e.path,
+		modTime: modTime,
+	}, nil
+}
+
+// fileInfoWrapper wraps remote file info
+type fileInfoWrapper struct {
+	name    string
+	path    string
+	modTime time.Time
+	size    int64
+}
+
+func (f *fileInfoWrapper) Name() string {
+	return f.name
+}
+
+func (f *fileInfoWrapper) Size() int64 {
+	return f.size
+}
+
+func (f *fileInfoWrapper) Mode() fs.FileMode {
+	return fs.ModeSymlink
+}
+
+func (f *fileInfoWrapper) ModTime() time.Time {
+	return f.modTime
+}
+
+func (f *fileInfoWrapper) IsDir() bool {
+	return false
+}
+
+func (f *fileInfoWrapper) Sys() interface{} {
+	return nil
+}
+
+type remoteFileReader struct {
+	executor exec.Executor
+}
+
+func (r *remoteFileReader) readFile(path string) ([]byte, error) {
+	cmd, err := r.executor.Command("cat", path)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	cmd.SetStdout(&buf)
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+type remoteFileDeleter struct {
+	executor exec.Executor
+}
+
+func (r *remoteFileDeleter) delete(path string) error {
+	// Check if sudo is needed:
+	// - NixOS system profiles: always need sudo
+	// - Home Manager root user profiles: need sudo
+	// - Home Manager regular user profiles: no sudo needed
+	needsSudo := strings.Contains(path, "/nix/var/nix/profiles/system-") ||
+		strings.Contains(path, "/nix/var/nix/profiles/per-user/root/")
+
+	var cmd exec.Command
+	var err error
+	if needsSudo {
+		cmd, err = exec.CommandWithSudoIfNeeded(r.executor, "rm", path)
+	} else {
+		cmd, err = r.executor.Command("rm", path)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Set stdin/stderr/stdout for sudo password prompts
+	if needsSudo {
+		cmd.SetStdin(os.Stdin)
+		cmd.SetStderr(os.Stderr)
+		cmd.SetStdout(os.Stdout)
+	}
+
+	return cmd.Run()
+}
+
+// Factory functions
+
+// createReaders creates the appropriate reader implementations based on the executor.
+func createReaders(e exec.Executor) (linkReader, dirReader, fileReader) {
+	if e == nil || e.IsLocal() {
+		return &localLinkReader{}, &localDirReader{}, &localFileReader{}
+	}
+	return &remoteLinkReader{executor: e}, &remoteDirReader{executor: e}, &remoteFileReader{executor: e}
+}
+
+// createDeleter creates the appropriate deleter implementation based on the executor.
+func createDeleter(e exec.Executor) fileDeleter {
+	if e == nil || e.IsLocal() {
+		return &localFileDeleter{}
+	}
+	return &remoteFileDeleter{executor: e}
+}
+
+// createHomeDirResolver creates the appropriate home directory resolver based on the executor.
+func createHomeDirResolver(e exec.Executor) homeDirResolver {
+	if e == nil || e.IsLocal() {
+		return &localHomeDirResolver{}
+	}
+	return &remoteHomeDirResolver{executor: e}
 }

--- a/internal/generation/home.go
+++ b/internal/generation/home.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/arnarg/nilla-utils/internal/exec"
 	"github.com/arnarg/nilla-utils/internal/util"
 )
-
 
 // localHomeProfileDirs returns the list of profile directories to check for local operations.
 func localHomeProfileDirs() []string {
@@ -43,6 +43,9 @@ func homeProfileDirsFor(user string, homeResolver homeDirResolver) ([]string, er
 
 // findCurrentHomeGenerationPath is the shared helper that finds the current Home Manager generation path.
 // It checks both /nix/var/nix/profiles/per-user/<user> and ~/.local/state/nix/profiles locations.
+// Two layouts are supported:
+//   1) Standalone Home Manager:   home-manager -> home-manager-<id>-link
+//   2) NixOS module integration:  profile      -> profile-<id>-link   (takes precedence if present)
 func findCurrentHomeGenerationPath(user string, homeResolver homeDirResolver, linkReader linkReader) (string, error) {
 	dirs, err := homeProfileDirsFor(user, homeResolver)
 	if err != nil {
@@ -50,12 +53,20 @@ func findCurrentHomeGenerationPath(user string, homeResolver homeDirResolver, li
 	}
 
 	for _, dir := range dirs {
-		homeManagerLink := fmt.Sprintf("%s/home-manager", dir)
-		exists, err := linkReader.pathExists(homeManagerLink)
-		if err != nil {
-			continue
+		// Prefer NixOS module-style layout: profile -> profile-<id>-link
+		profileLink := fmt.Sprintf("%s/profile", dir)
+		exists, err := linkReader.pathExists(profileLink)
+		if err == nil && exists {
+			linkName, err := linkReader.readLink(profileLink)
+			if err == nil {
+				return fmt.Sprintf("%s/%s", dir, linkName), nil
+			}
 		}
-		if exists {
+
+		// Fallback to standalone Home Manager layout: home-manager -> home-manager-<id>-link
+		homeManagerLink := fmt.Sprintf("%s/home-manager", dir)
+		exists, err = linkReader.pathExists(homeManagerLink)
+		if err == nil && exists {
 			linkName, err := linkReader.readLink(homeManagerLink)
 			if err == nil {
 				return fmt.Sprintf("%s/%s", dir, linkName), nil
@@ -66,11 +77,16 @@ func findCurrentHomeGenerationPath(user string, homeResolver homeDirResolver, li
 	return "", errors.New("current generation not found")
 }
 
-// CurrentHomeGeneration returns the current Home Manager generation using local filesystem operations.
-func CurrentHomeGeneration() (*HomeGeneration, error) {
-	user := util.GetUser()
-	homeResolver := &localHomeDirResolver{}
-	linkReader := &localLinkReader{}
+// CurrentHomeGeneration returns the current Home Manager generation using the given executor.
+// If executor is nil or local, uses local filesystem. If username is provided, uses it for remote queries.
+func CurrentHomeGeneration(e exec.Executor, username string) (*HomeGeneration, error) {
+	user := username
+	if user == "" {
+		user = util.GetUser()
+	}
+
+	homeResolver := createHomeDirResolver(e)
+	linkReader, dirReader, fileReader := createReaders(e)
 
 	path, err := findCurrentHomeGenerationPath(user, homeResolver, linkReader)
 	if err != nil {
@@ -78,7 +94,7 @@ func CurrentHomeGeneration() (*HomeGeneration, error) {
 	}
 
 	// Convert path to HomeGeneration struct
-	return pathToHomeGeneration(path)
+	return pathToHomeGeneration(path, dirReader, fileReader, linkReader)
 }
 
 // CurrentHomeGenerationPath queries the current Home Manager generation path using the given executor.
@@ -90,16 +106,8 @@ func CurrentHomeGenerationPath(e exec.Executor, username string) (string, bool) 
 		user = util.GetUser()
 	}
 
-	var homeResolver homeDirResolver
-	var linkReader linkReader
-
-	if e.IsLocal() {
-		homeResolver = &localHomeDirResolver{}
-		linkReader = &localLinkReader{}
-	} else {
-		homeResolver = &remoteHomeDirResolver{executor: e}
-		linkReader = &remoteLinkReader{executor: e}
-	}
+	homeResolver := createHomeDirResolver(e)
+	linkReader, _, _ := createReaders(e)
 
 	path, err := findCurrentHomeGenerationPath(user, homeResolver, linkReader)
 	if err != nil {
@@ -110,18 +118,18 @@ func CurrentHomeGenerationPath(e exec.Executor, username string) (string, bool) 
 }
 
 // pathToHomeGeneration converts a generation path string to a HomeGeneration struct.
-// This is used for local operations where we need the full struct with metadata.
-func pathToHomeGeneration(path string) (*HomeGeneration, error) {
+// This works with both local and remote executors.
+func pathToHomeGeneration(path string, dirReader dirReader, fileReader fileReader, linkReader linkReader) (*HomeGeneration, error) {
 	// Extract directory from path
 	dir := filepath.Dir(path)
 
 	// Get file info
-	info, err := os.Stat(path)
+	info, err := dirReader.stat(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewHomeGeneration(dir, info)
+	return NewHomeGeneration(dir, info, fileReader, linkReader)
 }
 
 type HomeGeneration struct {
@@ -132,13 +140,15 @@ type HomeGeneration struct {
 	path string
 }
 
-func NewHomeGeneration(root string, info fs.FileInfo) (*HomeGeneration, error) {
-	// Get ID from name
-	strID := regexp.MustCompile(`^home-manager-(\d+)-link$`).FindStringSubmatch(info.Name())
-	if strID[1] == "" {
-		return nil, fmt.Errorf("generation path '%s' does not match pattern", info.Name())
+func NewHomeGeneration(root string, info fs.FileInfo, fileReader fileReader, linkReader linkReader) (*HomeGeneration, error) {
+	// Get ID from name. Support both standalone and NixOS module layouts:
+	//   home-manager-<id>-link  (standalone)
+	//   profile-<id>-link       (NixOS module)
+	matches := regexp.MustCompile(`^(?:home-manager|profile)-(\d+)-link$`).FindStringSubmatch(info.Name())
+	if len(matches) < 2 || matches[1] == "" {
+		return nil, fmt.Errorf("generation path '%s' does not match supported patterns", info.Name())
 	}
-	id, err := strconv.Atoi(strID[1])
+	id, err := strconv.Atoi(matches[1])
 	if err != nil {
 		return nil, err
 	}
@@ -146,24 +156,48 @@ func NewHomeGeneration(root string, info fs.FileInfo) (*HomeGeneration, error) {
 	// Build full path
 	path := fmt.Sprintf("%s/%s", root, info.Name())
 
-	// Read home-manager version
-	homeVer, err := os.ReadFile(fmt.Sprintf("%s/hm-version", path))
-	if err != nil {
-		return nil, err
+	// Determine if this is a NixOS module generation (profile-*-link) or standalone (home-manager-*-link)
+	isNixOSModule := strings.HasPrefix(info.Name(), "profile-")
+
+	// Read version: "from NixOS" for NixOS module, hm-version for standalone
+	var version string
+	if isNixOSModule {
+		// NixOS module generation: set version to "from NixOS"
+		version = "from NixOS"
+	} else {
+		// Standalone Home Manager generation: read hm-version
+		homeVer, err := fileReader.readFile(fmt.Sprintf("%s/hm-version", path))
+		if err != nil {
+			// If hm-version doesn't exist, use empty string
+			version = ""
+		} else {
+			version = string(bytes.TrimSpace(homeVer))
+		}
 	}
 
 	return &HomeGeneration{
 		ID:        id,
 		BuildDate: info.ModTime(),
-		Version:   string(bytes.TrimSpace(homeVer)),
+		Version:   version,
 		path:      path,
 	}, nil
 }
 
 func (g *HomeGeneration) Delete() error {
-	if err := os.Remove(g.path); err != nil {
-		if os.IsNotExist(err) {
-			return nil
+	return g.DeleteWithExecutor(nil)
+}
+
+func (g *HomeGeneration) DeleteWithExecutor(e exec.Executor) error {
+	deleter := createDeleter(e)
+
+	if err := deleter.delete(g.path); err != nil {
+		// Check if it's a "not exist" error
+		if e != nil && !e.IsLocal() {
+			// For remote, check if file exists
+			exists, _ := e.PathExists(g.path)
+			if !exists {
+				return nil // File already deleted
+			}
 		}
 		return err
 	}
@@ -174,11 +208,29 @@ func (g *HomeGeneration) Path() string {
 	return g.path
 }
 
-func ListHomeGenerations() ([]*HomeGeneration, error) {
-	dirs := localHomeProfileDirs()
+// ListHomeGenerations lists all Home Manager generations using the given executor.
+// If executor is nil or local, uses local filesystem. If username is provided, uses it for remote queries.
+func ListHomeGenerations(e exec.Executor, username string) ([]*HomeGeneration, error) {
+	user := username
+	if user == "" {
+		user = util.GetUser()
+	}
+
+	homeResolver := createHomeDirResolver(e)
+	linkReader, dirReader, fileReader := createReaders(e)
+
+	dirs, err := homeProfileDirsFor(user, homeResolver)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, dir := range dirs {
-		gens, err := listHomeGenerations(dir)
+		gens, err := listHomeGenerations(dir, dirReader, fileReader, linkReader)
 		if err != nil {
+			// If directory doesn't exist, continue to next
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return nil, err
 		}
 		if len(gens) > 0 {
@@ -189,9 +241,9 @@ func ListHomeGenerations() ([]*HomeGeneration, error) {
 	return []*HomeGeneration{}, nil
 }
 
-func listHomeGenerations(dir string) ([]*HomeGeneration, error) {
+func listHomeGenerations(dir string, dirReader dirReader, fileReader fileReader, linkReader linkReader) ([]*HomeGeneration, error) {
 	// List files in dir
-	entries, err := os.ReadDir(dir)
+	entries, err := dirReader.readDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return []*HomeGeneration{}, nil
@@ -199,23 +251,45 @@ func listHomeGenerations(dir string) ([]*HomeGeneration, error) {
 		return nil, err
 	}
 
-	// Iterate over entries and build list of generations
-	generations := []*HomeGeneration{}
-	regex := regexp.MustCompile(`^home-manager-\d+-link$`)
-	for _, e := range entries {
-		if e.Type()&fs.ModeSymlink != 0 && regex.MatchString(e.Name()) {
-			info, err := e.Info()
-			if err != nil {
-				return nil, err
-			}
+	// Separate NixOS-module-style and standalone Home Manager generations.
+	// If any profile-<id>-link entries exist, they take precedence.
+	profileRegex := regexp.MustCompile(`^profile-\d+-link$`)
+	homeRegex := regexp.MustCompile(`^home-manager-\d+-link$`)
 
-			generation, err := NewHomeGeneration(dir, info)
-			if err != nil {
-				return nil, err
-			}
+	profileEntries := []fs.DirEntry{}
+	homeEntries := []fs.DirEntry{}
 
-			generations = append(generations, generation)
+	for _, entry := range entries {
+		if entry.Type()&fs.ModeSymlink == 0 {
+			continue
 		}
+		switch {
+		case profileRegex.MatchString(entry.Name()):
+			profileEntries = append(profileEntries, entry)
+		case homeRegex.MatchString(entry.Name()):
+			homeEntries = append(homeEntries, entry)
+		}
+	}
+
+	// Choose which set of entries to use. NixOS module (profile-*) supersedes standalone.
+	candidates := profileEntries
+	if len(candidates) == 0 {
+		candidates = homeEntries
+	}
+
+	generations := []*HomeGeneration{}
+	for _, entry := range candidates {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+
+		generation, err := NewHomeGeneration(dir, info, fileReader, linkReader)
+		if err != nil {
+			return nil, err
+		}
+
+		generations = append(generations, generation)
 	}
 
 	return generations, nil

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -3,7 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
-	"os/exec"
+	osexec "os/exec"
 	"os/user"
 	"strconv"
 	"strings"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -98,10 +99,11 @@ func IsRoot() bool {
 	return uid == 0
 }
 
+
 func SelfElevate() error {
 	args := append([]string{"sudo"}, os.Args...)
 
-	spath, err := exec.LookPath("sudo")
+	spath, err := osexec.LookPath("sudo")
 	if err != nil {
 		return err
 	}
@@ -161,4 +163,17 @@ func BuildStoreAddress(user, hostname string) string {
 		user = GetUser()
 	}
 	return fmt.Sprintf("ssh-ng://%s@%s", user, hostname)
+}
+
+// ValidateArgs validates command arguments and returns an error if there are unexpected arguments.
+// maxArgs specifies the maximum number of arguments allowed (0 means no arguments, 1 means at most one argument).
+func ValidateArgs(cmd *cli.Command, maxArgs int) error {
+	argCount := cmd.Args().Len()
+	if argCount > maxArgs {
+		// Get all unexpected arguments
+		args := cmd.Args().Slice()
+		unexpected := args[maxArgs:]
+		return fmt.Errorf("unexpected argument(s): %s", strings.Join(unexpected, " "))
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Adds support for remote generation operations and adds centralized sudo handling.

## New Features

- Added support for listing and cleaning generations on remote hosts
- Added `IsRootOnExecutor()` and `CommandWithSudoIfNeeded()` to `internal/exec/exec.go`
  - Automatically detects if running as root (local or remote)
  - Only adds `sudo` prefix when needed
  - Eliminates duplicate root checking logic across the codebase

## Code Quality Improvements

- Refactored `nix.CopyToTarget()` to eliminate duplicated copy logic between `nilla-os` and `nilla-home`

## Usage

### NixOS Generations

```sh
# List generations locally
nilla os generations list

# Cleanup generations locally (keeps last 3)
nilla os generations clean --keep 3

# List generations on remote host
nilla os --target <user@target> generations list

# Cleanup generations on remote host
nilla os --target <user@target> generations clean --keep 3
```

### Home Manager Generations

```sh
# List generations locally
nilla home generations list

# Cleanup generations locally (keeps last 3)
nilla home generations clean --keep 3

# For remote host - connect as current user
nilla home --target <target> generations list
nilla home --target <target> generations clean --keep 3

# For remote host - connect as specific user
nilla home --target <user@target> generations list
nilla home --target <user@target> generations clean --keep 3

# For remote host - connect as specific user and use specific Home Manager configuration
# (configuration must exist in "nilla home list" and hostname must match target)
nilla home --target <user@target> generations list <user@system_name>
nilla home --target <user@target> generations clean --keep 3 <user@system_name>
```

## Implementation

Needs remote build code from #22.

### NixOS Generation Retrieval

NixOS generations are stored in `/nix/var/nix/profiles/system-<id>-link` symlinks:

1. **Current generation**: Reads `/nix/var/nix/profiles/system` symlink to find the current generation
2. **List generations**: Lists all `system-<id>-link` entries in `/nix/var/nix/profiles`
3. **Generation metadata**: Reads `nixos-version` file and kernel version from `kernel-modules/lib/modules` directory

### Home Manager Generation Retrieval

Home Manager generations can be in two locations:
- `/nix/var/nix/profiles/per-user/<user>/` (system-wide)
- `~/.local/state/nix/profiles/` (user-specific)

Two layouts are supported:
1. **NixOS module integration**: `profile -> profile-<id>-link` (takes precedence)
2. **Standalone Home Manager**: `home-manager -> home-manager-<id>-link`

The retrieval process:
1. **Current generation**: Checks both locations and layouts, preferring NixOS module style
2. **List generations**: Scans directories for matching symlink patterns
3. **Generation metadata**: Reads `hm-version` for standalone, or marks as "from NixOS" for module integration

For remote operations, home directory resolution uses:
- `getent passwd <user>` (if available) to get home directory
- Falls back to `eval echo ~<user>` shell expansion
